### PR TITLE
CI: Add GitHub Actions workflow to build Android library

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,43 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "master", "main" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install SDK packages
+        shell: bash
+        run: |
+          sdkmanager --install \
+            "platforms;android-34" \
+            "build-tools;34.0.0" \
+            "platform-tools"
+          yes | sdkmanager --licenses
+
+      - name: Build library
+        run: ./gradlew :veridui:assemble --no-daemon --stacktrace
+
+      - name: Run checks (no-UI)
+        run: ./gradlew :veridui:test --no-daemon --stacktrace
+


### PR DESCRIPTION
This PR introduces a minimal GitHub Actions workflow that:

- Sets up JDK 17 and Android SDK (API 34, build-tools 34.0.0)
- Caches Gradle via `gradle/actions/setup-gradle`
- Builds the library module (`:veridui:assemble`) and runs unit tests (`:veridui:test`)

Rationale:
- Provides automated verification for PRs and pushes
- Aligns with current project configuration (AGP 8.x, Java 17)
- Keeps scope small and non-invasive; no changes to code

Future follow-ups could add lint checks and build the sample module if desired.