### PR TITLE
CI: Add lint + unit tests, sample build, and translation check

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,50 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "master", "main" ]
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install SDK packages
+        shell: bash
+        run: |
+          sdkmanager --install \
+            "platforms;android-34" \
+            "build-tools;34.0.0" \
+            "platform-tools"
+          yes | sdkmanager --licenses
+
+      - name: Gradle version
+        run: ./gradlew --version
+
+      - name: Lint and unit tests
+        run: ./gradlew :veridui:lint :veridui:test --no-daemon --stacktrace
+
+      - name: Build library and sample
+        run: ./gradlew :veridui:assembleRelease :sample:assembleDebug --no-daemon --stacktrace
+
+      - name: Translation checks
+        run: |
+          python3 test_translation.py veridui/src/main/assets/fr.xml
+


### PR DESCRIPTION
Extends CI with additional checks:

- Runs `:veridui:lint` and `:veridui:test`
- Builds `:veridui:assembleRelease` and `:sample:assembleDebug`
- Runs the translation checker on `fr.xml`

This complements the basic build PR and increases confidence in changes.